### PR TITLE
Fix env variable

### DIFF
--- a/lib/crystal_sdk.rb
+++ b/lib/crystal_sdk.rb
@@ -7,9 +7,6 @@ module CrystalSDK
   autoload :Profile, 'crystal_sdk/profile'
   autoload :EmailSample, 'crystal_sdk/email_sample'
 
-  crystal_env_key = ENV['CRYSTAL_KEY']
-  CrystalSDK.key = crystal_env_key if crystal_env_key
-
   class << self
     def key
       Base.key
@@ -27,4 +24,7 @@ module CrystalSDK
       Base.key = value
     end
   end
+
+  crystal_env_key = ENV['CRYSTAL_KEY']
+  CrystalSDK.key = crystal_env_key if crystal_env_key
 end


### PR DESCRIPTION
Setting `ENV['CRYSTAL_KEY']` would cause the gem to throw `Gem Load Error is: undefined method 'key=' for CrystalSDK:Module`.

To fix it, move use of `CrystalSDK.key` to after it is defined.