### PR TITLE
Expose the request id when doing a profile search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    crystal_sdk (1.1.1)
+    crystal_sdk (1.2.1)
       nestful (~> 1.1)
       recursive-open-struct (~> 1.0)
 
@@ -14,9 +14,9 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     hashdiff (0.3.2)
-    nestful (1.1.1)
+    nestful (1.1.3)
     public_suffix (2.0.5)
-    recursive-open-struct (1.0.4)
+    recursive-open-struct (1.1.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -45,4 +45,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ end
   end
 ```
 
+
+### Relationships
+```ruby
+profile1 = CrystalSDK::Profile.search({})
+profile2 = CrystalSDK::Profile.search({})
+CrystalSDK::Api.make_request(:post, "relationships/#{profile1.request_id}/#{profile2.request_id}")
+```
+
 ## Asynchronous Flow (For bulk analysis)
 
 When requesting large amounts of profiles, or when wanting to have more fine-grained control over performance, we recommend using our asynchronous flow. It allows us to process your requests in parallel and get the information back to you more quickly. There are a couple options for using this capability.

--- a/lib/crystal_sdk/profile.rb
+++ b/lib/crystal_sdk/profile.rb
@@ -4,11 +4,12 @@ require_relative 'profile/request'
 
 module CrystalSDK
   class Profile
-    attr_reader :info, :recommendations
+    attr_reader :info, :recommendations, :request_id
 
-    def initialize(info, recommendations)
+    def initialize(info:, recommendations:, request_id:)
       @info = info
       @recommendations = recommendations
+      @request_id = request_id
     end
 
     class << self
@@ -16,7 +17,7 @@ module CrystalSDK
         return nil unless req.did_find_profile?
 
         profile_info = req.profile_info
-        Profile.new(profile_info[:info], profile_info[:recommendations])
+        Profile.new(info: profile_info[:info], recommendations: profile_info[:recommendations], request_id: req.id)
       end
 
       def search(query, timeout: 30)

--- a/spec/crystal_sdk/profile_spec.rb
+++ b/spec/crystal_sdk/profile_spec.rb
@@ -9,6 +9,7 @@ describe CrystalSDK::Profile do
 
     it 'should use the correct request' do
       resp = double(
+        id: 'deadbeef',
         did_finish?: true,
         did_find_profile?: true,
         profile_info: { info: 'info', recommendations: 'recs' }


### PR DESCRIPTION
This enables accessing the relationships API using the results from the profile search